### PR TITLE
[LNX-2434] Support compiling with clang9, this is implicitly deleted ctor

### DIFF
--- a/include/spdlog/details/log_msg.h
+++ b/include/spdlog/details/log_msg.h
@@ -31,7 +31,6 @@ struct log_msg
     }
 
     log_msg(const log_msg &other) = default;
-    log_msg &operator=(const log_msg &other) = default;
 
     const std::string *logger_name{nullptr};
     level::level_enum level{level::off};


### PR DESCRIPTION
../3rd_parties/spdlog/include/spdlog/details/log_msg.h:34:14: error: explicitly defaulted copy assignment operator is implicitly deleted [-Werror,-Wdefaulted-function-deleted]
    log_msg &operator=(const log_msg &other) = default;
